### PR TITLE
docs: adds missing github action permissions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ originally created by Google and licensed under Apache 2.0.
 
    permissions:
      contents: write
+     issues: write
      pull-requests: write
 
    name: release-please
@@ -124,6 +125,7 @@ This workflow will need the following permissions in your workflow file:
 ```yml
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 ```
 


### PR DESCRIPTION
Port of original PR's https://github.com/googleapis/release-please-action/pull/1108 and https://github.com/googleapis/release-please-action/pull/1120. All original changes are attributed to @this-oliver and @shinebayar-g