### PR TITLE
feat: add bootstrap-sha to inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ steps:
 | `skip-github-release`      | If `true`, do not attempt to create releases. This is useful if splitting release tagging from PR creation.                            |
 | `skip-github-pull-request` | If `true`, do not attempt to create release pull requests. This is useful if splitting release tagging from PR creation.               |
 | `skip-labeling`            | If `true`, do not attempt to label the PR.                                                                                             |
+| `bootstrap-sha`            | How far back (exclusive) to pull commits for conventional commit parsing.                                                               |
 | `config-overrides-json`    | JSON string of release-please configuration options. Allows inline configuration without a separate config file.                       |
 
 ## GitHub Credentials

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,10 @@ inputs:
     description: 'if set to true, then do not try to label the PR'
     required: false
     default: false
+  bootstrap-sha:
+    description: 'How far back (exclusive) to pull commits for conventional commit parsing.'
+    required: false
+    default: ''
   changelog-host:
     description: 'The proto://host where commits live. Default `https://github.com`'
     required: false

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -136,6 +136,20 @@ describe('release-please-action', () => {
 
         expect(fromConfigStub).toHaveBeenCalled();
       });
+
+      it('allows specifying bootstrap-sha', async () => {
+        mockInputs({
+          'bootstrap-sha': 'abc123def',
+          'release-type': 'simple',
+        });
+        fakeManifest.createReleases.mockResolvedValue([]);
+        fakeManifest.createPullRequests.mockResolvedValue([]);
+        await action.main();
+        expect(fakeManifest.createReleases).toHaveBeenCalledTimes(1);
+        expect(fakeManifest.createPullRequests).toHaveBeenCalledTimes(1);
+
+        expect(fromConfigStub).toHaveBeenCalled();
+      });
     });
 
     describe('with manifest', () => {
@@ -202,6 +216,63 @@ describe('release-please-action', () => {
         expect(fakeManifest.createPullRequests).toHaveBeenCalledTimes(1);
 
         expect(fromManifestStub).toHaveBeenCalled();
+      });
+
+      it('allows specifying bootstrap-sha', async () => {
+        mockInputs({
+          'bootstrap-sha': 'abc123def',
+        });
+        fakeManifest.createReleases.mockResolvedValue([]);
+        fakeManifest.createPullRequests.mockResolvedValue([]);
+        await action.main();
+        expect(fakeManifest.createReleases).toHaveBeenCalledTimes(1);
+        expect(fakeManifest.createPullRequests).toHaveBeenCalledTimes(1);
+
+        expect(fromManifestStub).toHaveBeenCalled();
+      });
+
+      it('correctly filters undefined values in manifest overrides', async () => {
+        mockInputs({
+          'skip-labeling': 'true',
+        });
+        fakeManifest.createReleases.mockResolvedValue([]);
+        fakeManifest.createPullRequests.mockResolvedValue([]);
+        await action.main();
+        expect(fakeManifest.createReleases).toHaveBeenCalledTimes(1);
+        expect(fakeManifest.createPullRequests).toHaveBeenCalledTimes(1);
+
+        expect(fromManifestStub).toHaveBeenCalledWith(
+          expect.any(Object),
+          expect.any(String),
+          expect.any(String),
+          expect.any(String),
+          expect.objectContaining({
+            skipLabeling: true,
+          })
+        );
+      });
+
+      it('includes bootstrap-sha in manifest overrides when provided', async () => {
+        mockInputs({
+          'bootstrap-sha': 'abc123def',
+          'fork': 'true',
+        });
+        fakeManifest.createReleases.mockResolvedValue([]);
+        fakeManifest.createPullRequests.mockResolvedValue([]);
+        await action.main();
+        expect(fakeManifest.createReleases).toHaveBeenCalledTimes(1);
+        expect(fakeManifest.createPullRequests).toHaveBeenCalledTimes(1);
+
+        expect(fromManifestStub).toHaveBeenCalledWith(
+          expect.any(Object),
+          expect.any(String),
+          expect.any(String),
+          expect.any(String),
+          expect.objectContaining({
+            fork: true,
+            bootstrapSha: 'abc123def',
+          })
+        );
       });
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ interface ActionInputs {
   skipGitHubRelease?: boolean;
   skipGitHubPullRequest?: boolean;
   skipLabeling?: boolean;
+  bootstrapSha?: string;
   fork?: boolean;
   includeComponentInTag?: boolean;
   changelogHost: string;
@@ -71,6 +72,7 @@ function parseInputs(): ActionInputs {
     skipGitHubRelease: getOptionalBooleanInput('skip-github-release'),
     skipGitHubPullRequest: getOptionalBooleanInput('skip-github-pull-request'),
     skipLabeling: getOptionalBooleanInput('skip-labeling'),
+    bootstrapSha: getOptionalInput('bootstrap-sha'),
     fork: getOptionalBooleanInput('fork'),
     includeComponentInTag: getOptionalBooleanInput('include-component-in-tag'),
     changelogHost: core.getInput('changelog-host') || DEFAULT_GITHUB_SERVER_URL,
@@ -134,12 +136,13 @@ function loadOrBuildManifest(
   github: GitHub,
   inputs: ActionInputs
 ): Promise<Manifest> {
-  const manifestOverrides = inputs.fork || inputs.skipLabeling
-    ? {
-        fork: inputs.fork,
-        skipLabeling: inputs.skipLabeling,
-      }
-    : {};
+  const manifestOverrides = Object.fromEntries(
+    Object.entries({
+      fork: inputs.fork,
+      skipLabeling: inputs.skipLabeling,
+      bootstrapSha: inputs.bootstrapSha,
+    }).filter(([key, value]) => value !== undefined),
+  );
 
   const releaserConfig = Object.fromEntries(
     Object.entries(extractReleaserConfig(inputs.configOverrides)).filter(([key, value]) => value !== undefined),


### PR DESCRIPTION
Adding new manifest-based input `bootstrap-sha`. We need to think about passing all manifest options same way as we do with release ones in the future, but this will do for now.